### PR TITLE
Account Details API Endpoint

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -73,3 +73,16 @@ The response is a JSON object with fields:
 * `success`: whether the account creation succeeded
 * `errorCode`: string, optional, machine-readable description of the error. Possible values include: `ACCOUNT_EXISTS`, `INVALID_PASSPHRASE`, `UNKNOWN_ERROR`.
 * `error`: string, optional, human-readable description of the failure.
+
+`/v1/account_details`
+----------------
+
+This endpoint fetches account details and returns them as JSON. The request is a JSON object with fields:
+
+* `accountName`: string, name of the account
+
+The response is a JSON object with fields:
+
+* `success`: whether the account exists or not
+* `accountName`: canonical, case-unfolded version of the account name
+* `Email`: email address of the account provided


### PR DESCRIPTION
This endpoint should make it possible to fetch additional information of the account provided.
For the time being it will be the email address, which would be useful for external apps such as Discourse, but can be extended to all sorts of information that might be needed for external services.